### PR TITLE
Updating to 0.53 - Bug Fix on Fresh Install

### DIFF
--- a/scripts/autostart.lic
+++ b/scripts/autostart.lic
@@ -9,10 +9,12 @@
   contributors: Athias, Doug
           game: any
           tags: core
-       version: 0.52
+       version: 0.53
       required: Lich >= 4.6.58
 
   changelog:
+    0.53 (2021-07-27):
+      Fixed defect where autostart would error if a completely new / fresh install with no lich.db3 existing.
     0.52 (2021-05-10):
       Fixed removal of lich being updated when running Lich5
     0.51 (2020-09-09):
@@ -66,8 +68,8 @@ def lich_no_update
   	retry
 	end
 
-	hash = Marshal.load(blob)
-	if hash['updatable'][:lich]
+	hash = Marshal.load(blob) if blob
+	if hash['updatable'][:lich] || !hash
 		return true
 	else
 		return false


### PR DESCRIPTION
On a completely fresh install (new player install), autostart would fail to run if repository hadn't already been run.

To fix, detect if there is an existing repository setting.  If not, run repository with unset-lich-updatable parameter.